### PR TITLE
Use parentheses to remove the ambiguity

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule Rop.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
+     package: package(),
      docs: [extras: ["README.md"]],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
I get the following warnings

    warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
      /project_path/deps/rop/mix.exs:12
    
    warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
      /project_path/deps/rop/mix.exs:14```