### PR TITLE
Minor Cleanup/Improvements

### DIFF
--- a/lib/rop.ex
+++ b/lib/rop.ex
@@ -97,7 +97,7 @@ defmodule Rop do
     quote do
       (fn ->
         try do
-          unquote(args) |> unquote(func)
+          {:ok, unquote(args) |> unquote(func)}
         rescue
           e -> {:error, e}
         end

--- a/lib/rop.ex
+++ b/lib/rop.ex
@@ -15,19 +15,28 @@ defmodule Rop do
   Raise the arguments else
 
   For example:
-      iex> ok({:ok, 1})
+      iex> do_try({:ok, 1})
       1
 
-      iex> ok({:error, "some"})
+      iex> do_try({:error, "some"})
       ** (RuntimeError) some
 
-      iex> ok({:anything, "some"})
+      iex> do_try({:anything, "some"})
       ** (ArgumentError) raise/1 and reraise/2 expect a module name, string or exception as the first argument, got: {:anything, \"some\"}
   """
-  def ok({:ok, x}), do: x
-  def ok({:error, x}), do: raise x
-  def ok(x), do: raise x
+  def do_try({:ok, x}), do: x
+  def do_try({:error, x}), do: raise x
+  def do_try(x), do: raise x
 
+  @doc ~s"""
+    Wraps the value in an ok tagged tuple like {:ok, value}
+  """
+  def ok(x), do: {:ok, x}
+
+  @doc ~s"""
+    Wraps the value in an error tagged tuple like {:error, value}
+  """
+  def err(x), do: {:error, x}
 
   @doc ~s"""
     No need to stop pipelining in case of an error somewhere in the middle

--- a/lib/rop.ex
+++ b/lib/rop.ex
@@ -31,6 +31,8 @@ defmodule Rop do
   @doc ~s"""
     Wraps the value in an ok tagged tuple like {:ok, value}
   """
+  def ok({:ok, x}), do: {:ok, x}
+  def ok({:error, x}), do: {:error, x}
   def ok(x), do: {:ok, x}
 
   @doc ~s"""

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Rop.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ex_spec, "~> 1.0", only: :test},
+      {:ex_spec, "~> 2.0", only: :test},
       {:earmark, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.2.0"},
-  "ex_doc": {:hex, :ex_doc, "0.11.3"},
-  "ex_spec": {:hex, :ex_spec, "1.0.0"}}
+%{
+  "earmark": {:hex, :earmark, "0.2.0", "bc1636bc2efa0c1c172a5bcbf7c8eb73632d8c4512a6c2dac02d2ae454750af6", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.11.3", "bb16cb3f4135d880ce25279dc19a9d70802bc4f4942f0c3de9e4862517ae3ace", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm"},
+}

--- a/test/rop_test.exs
+++ b/test/rop_test.exs
@@ -5,7 +5,7 @@ defmodule RopTest do
   doctest Rop
 
 
-  ExSpec.describe ">>> macro" do
+  describe ">>> macro" do
     test "returns the piped value in case of happy path" do
       assert (0 |> inc >>> inc >>> inc) == {:ok, 3}
     end
@@ -23,7 +23,7 @@ defmodule RopTest do
     end
   end
 
-  ExSpec.describe "try_catch macro" do
+  describe "try_catch macro" do
     test "catches and returns raised errors in a tagged tupple { :error, %SomeError{} } if something breaks" do
       assert (:raise |> try_catch(arithmetic_error)) == {:error, %ArithmeticError{}}
     end
@@ -33,7 +33,7 @@ defmodule RopTest do
     end
   end
 
-  ExSpec.describe "tee" do
+  describe "tee" do
     test "passes the arguments through after executing them in the function" do
       a = (fn ->
         0 |> simple_inc |> simple_inc |> tee(simple_sideeffect)
@@ -50,7 +50,7 @@ defmodule RopTest do
     end
   end
 
-  ExSpec.describe "bind" do
+  describe "bind" do
     test "wraps a function to return a tagged tuple `{:ok, result}` from the returned value" do
       a = 0 |> simple_inc |> bind(simple_inc)
       assert a == {:ok, 2}
@@ -80,6 +80,6 @@ defmodule RopTest do
   end
 
   defp arithmetic_error(:raise) do
-    1 / 0
+    raise ArithmeticError
   end
 end

--- a/test/rop_test.exs
+++ b/test/rop_test.exs
@@ -28,8 +28,8 @@ defmodule RopTest do
       assert (:raise |> try_catch(arithmetic_error)) == {:error, %ArithmeticError{}}
     end
 
-    test "returns the value otherwise" do
-      assert (:pass |> try_catch(arithmetic_error)) == 1
+    test "returns the piped value otherwise" do
+      assert (:pass |> try_catch(arithmetic_error)) == {:ok, 1}
     end
   end
 


### PR DESCRIPTION
This PR addresses various issues I've come across while using this library. A few are personal preference and will be labeled as such; others I believe are fundamental to the correct functioning of the library. If you'd like, I can separate the two and submit two PRs instead of this single one.
## Changes
1) `ok` has been renamed to `do_try`. This has been done in the spirit of Rust's `try` macro, and makes more sense in my opinion. I believe `ok` should wrap a value in an `:ok` result in order to make chaining more user-friendly.
2) I've also added an `err` function to provide a user-friendly way to wrap a value in an `:error` result.
3) When using `try_catch`, a method that does not raise should return a value wrapped in an `:ok` result. This conforms to the expectations laid out in https://zohaib.me/railway-programming-pattern-in-elixir/ and makes sense logically, and also makes code much easier to write. Tests have been updated to reflect this change as well.
4) ExSpec has been updated to eliminate compiler warnings.


Of these changes, 3) and 4) are logical changes that I believe should be made no matter what; 1) and 2) are stylistic changes that I prefer but which I understand may not make sense to be included in a wide release. As mentioned, I can split the changes if that is preferred.